### PR TITLE
Bump BuildX to 0.8.2, Golang to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,16 @@
 ###
 FROM alpine AS fetcher
 
-ARG BUILDX_VERSION=0.5.1
+ARG BUILDX_VERSION=0.8.2
 ADD https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-amd64 /docker-buildx
 RUN chmod a+x /docker-buildx
 
 ###
 # Get aws-cli helper
 ###
-FROM golang:1.16 AS builder
+FROM golang:1.18 AS builder
 
-RUN go get -ldflags "-linkmode external -extldflags -static" github.com/chialab/aws-ecr-get-login-password \
+RUN go install -ldflags "-linkmode external -extldflags -static" github.com/chialab/aws-ecr-get-login-password@latest \
     && cp $GOPATH/bin/aws-ecr-get-login-password /usr/local/bin/
 
 ###


### PR DESCRIPTION
This PR bumps the version of [Docker BuildX](https://github.com/docker/buildx) to 0.8.2 (latest version at the time of this writing) and GoLang to 1.18 (latest version at the time of this writing).